### PR TITLE
Use dirname instead of split

### DIFF
--- a/random_words/random_words.py
+++ b/random_words/random_words.py
@@ -5,7 +5,7 @@ import json
 from random import sample
 from itertools import chain
 
-main_dir = os.path.split(os.path.abspath(__file__))[0]
+main_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 class Random(dict):


### PR DESCRIPTION
os.path.dirname() is identical to os.path.split()[0] see: https://docs.python.org/3/library/os.path.html#os.path.dirname