### PR TITLE
Cast sets to list to silence Python 3.9 deprecation warnings

### DIFF
--- a/random_words/lorem_ipsum.py
+++ b/random_words/lorem_ipsum.py
@@ -41,7 +41,7 @@ class LoremIpsum(object):
             num_rand_words = random.randint(self.MIN_WORDS, self.MAX_WORDS)
 
             random_sentence = self.make_sentence(
-                random.sample(self.words, num_rand_words))
+                random.sample(list(self.words), num_rand_words))
 
             sentences_list.append(random_sentence)
             sentences -= 1

--- a/random_words/random_words.py
+++ b/random_words/random_words.py
@@ -225,7 +225,7 @@ class RandomEmails(Random):
         self.check_count(count)
 
         random_nicks = self.rn.random_nicks(count=count)
-        random_domains = sample(self.dmails, count)
+        random_domains = sample(list(self.dmails), count)
 
         return [
             nick.lower() + "@" + domain for nick, domain in zip(random_nicks,


### PR DESCRIPTION
```
/Users/user/env/name/lib/python3.9/site-packages/random_words/lorem_ipsum.py:44: DeprecationWarning: Sampling from a set deprecated
since Python 3.9 and will be removed in a subsequent version.
  random.sample(self.words, num_rand_words))
```