### PR TITLE
Migrate to pep517

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name='RandomWords'
+version='0.4.0'
+description='A useful module for a random text, e-mails and lorem ipsum.'
+readme = "README.rst"
+classifiers = [
+    'Intended Audience :: Developers',
+    'License :: OSI Approved :: MIT License',
+    'Programming Language :: Python',
+    'Natural Language :: English',
+    'Development Status :: 5 - Production/Stable',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Topic :: Software Development :: Libraries :: Python Modules'
+]
+dependencies = []
+license = {file = "LICENSE.txt"}
+
+[[project.authors]]
+name='Tomek Święcicki'
+email='tomislater@gmail.com'
+
+[project.urls]
+homepage='https://github.com/tomislater/RandomWords'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,26 +1,26 @@
 [project]
-name='RandomWords'
-version='0.4.0'
-description='A useful module for a random text, e-mails and lorem ipsum.'
+name = "RandomWords"
+version = "0.4.0"
+description = "A useful module for a random text, e-mails and lorem ipsum."
 readme = "README.rst"
 classifiers = [
-    'Intended Audience :: Developers',
-    'License :: OSI Approved :: MIT License',
-    'Programming Language :: Python',
-    'Natural Language :: English',
-    'Development Status :: 5 - Production/Stable',
-    'Programming Language :: Python :: 3.7',
-    'Programming Language :: Python :: 3.8',
-    'Programming Language :: Python :: 3.9',
-    'Programming Language :: Python :: 3.10',
-    'Topic :: Software Development :: Libraries :: Python Modules'
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python",
+    "Natural Language :: English",
+    "Development Status :: 5 - Production/Stable",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 dependencies = []
 license = {file = "LICENSE.txt"}
 
 [[project.authors]]
-name='Tomek Święcicki'
-email='tomislater@gmail.com'
+name = "Tomek Święcicki"
+email = "tomislater@gmail.com"
 
 [project.urls]
-homepage='https://github.com/tomislater/RandomWords'
+homepage = "https://github.com/tomislater/RandomWords"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,6 @@ email = "tomislater@gmail.com"
 
 [project.urls]
 homepage = "https://github.com/tomislater/RandomWords"
+
+[tool.setuptools]
+packages = [ "random_words" ]

--- a/setup.py
+++ b/setup.py
@@ -3,19 +3,25 @@
 import sys
 
 from setuptools import setup
-from setuptools.command.test import test as TestCommand
+try:
+    from setuptools.command.test import test as TestCommand
+except ImportError:
+    # setuptools.command.test has been removed.
+    # Since we can't define `PyTest`, there are no `cmdclass`es to use.
+    CMDCLASS = {}
+else:
+    class PyTest(TestCommand):
+        def finalize_options(self):
+            TestCommand.finalize_options(self)
+            self.test_args = ['--strict-markers', '--verbose', '--tb=long']
+            self.test_suite = True
 
-
-class PyTest(TestCommand):
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = ['--strict-markers', '--verbose', '--tb=long']
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        errcode = pytest.main(self.test_args)
-        sys.exit(errcode)
+        def run_tests(self):
+            import pytest
+            errcode = pytest.main(self.test_args)
+            sys.exit(errcode)
+    # Use `PyTest` as a `cmdclass`.
+    CMDCLASS = {'test': PyTest}
 
 
 setup(
@@ -43,9 +49,7 @@ setup(
     include_package_data=True,
     install_requires=[],
     tests_require=['pytest'],
-    cmdclass={'test': PyTest},
+    cmdclass=CMDCLASS,
     test_suite='random_words.test.test_random_words',
-    extras_require={
-         'testing': ['pytest'],
-     },
+    extras_require={ 'testing': ['pytest'] },
 )

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,6 @@ else:
 
 
 setup(
-    packages=['random_words'],
-    include_package_data=True,
-    install_requires=[],
     tests_require=['pytest'],
     cmdclass=CMDCLASS,
     test_suite='random_words.test.test_random_words',

--- a/setup.py
+++ b/setup.py
@@ -7,26 +7,28 @@ try:
     from setuptools.command.test import test as TestCommand
 except ImportError:
     # setuptools.command.test has been removed.
-    # Since we can't define `PyTest`, there are no `cmdclass`es to use.
-    CMDCLASS = {}
-else:
-    class PyTest(TestCommand):
-        def finalize_options(self):
-            TestCommand.finalize_options(self)
-            self.test_args = ['--strict-markers', '--verbose', '--tb=long']
-            self.test_suite = True
-
-        def run_tests(self):
-            import pytest
-            errcode = pytest.main(self.test_args)
-            sys.exit(errcode)
-    # Use `PyTest` as a `cmdclass`.
-    CMDCLASS = {'test': PyTest}
+    # The `setup` call is only necessary when defining this `cmdclass`, since
+    # building the project is no longer dependend on that.
+    # Therefore, there's no more to do here.
+    sys.exit()
 
 
+class PyTest(TestCommand):
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = ['--strict-markers', '--verbose', '--tb=long']
+        self.test_suite = True
+
+    def run_tests(self):
+        import pytest
+        errcode = pytest.main(self.test_args)
+        sys.exit(errcode)
+
+
+# Use `PyTest` as a `cmdclass`.
 setup(
     tests_require=['pytest'],
-    cmdclass=CMDCLASS,
+    cmdclass={'test': PyTest},
     test_suite='random_words.test.test_random_words',
-    extras_require={ 'testing': ['pytest'] },
+    extras_require={ 'testing': ['pytest'] }
 )

--- a/setup.py
+++ b/setup.py
@@ -25,27 +25,7 @@ else:
 
 
 setup(
-    name='RandomWords',
-    version='0.4.0',
-    author='Tomek Święcicki',
-    author_email='tomislater@gmail.com',
     packages=['random_words'],
-    url='https://github.com/tomislater/RandomWords',
-    license='LICENSE.txt',
-    description='A useful module for a random text, e-mails and lorem ipsum.',
-    long_description=open('README.rst').read(),
-    classifiers=[
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python',
-        'Natural Language :: English',
-        'Development Status :: 5 - Production/Stable',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-    ],
     include_package_data=True,
     install_requires=[],
     tests_require=['pytest'],


### PR DESCRIPTION
This changeset migrates the project to the new standard for building projects, described in [PEP 517 – A build-system independent format for source trees](https://peps.python.org/pep-0517/), and makes the implementation of the `PyTest` class and invocation of `setup` conditional upon successful import of `setuptools.command.test`.

This Setuptools functionality has been deprecated for many years - and so has the general use of Setuptools as a general "project manager" with extensible functionality for testing/development/etc. Currently, Setuptools is only intended for use to build [wheels](https://packaging.python.org/en/latest/specifications/binary-distribution-format/#binary-distribution-format) from sdists, either explicitly via a frontend such as [`build`](https://github.com/pypa/build/) or implicitly when installing a project with Pip.

The work is split into several commits and the log offers a detailed rationale for each change, with citations of the relevant standards.

This fixes #15 , even for users who get stuck with `setuptools==72.0.0`.

In addition to making this change, I strongly recommend building and distributing a wheel for the project. Pip also exposes this functionality directly: it's as easy as `python -m pip wheel .` in the root directory, which produces a `.whl` file that can be uploaded to PyPI exactly like the sdist (e.g., by using `twine`). Distributing the project this way [is much more convenient for end users](https://pradyunsg.me/blog/2022/12/31/wheels-are-faster-pure-python/), as it skips a completely unnecessary "build" step for this pure-Python project. (Pip cannot install the files directly from an sdist tarball, because it can't know whether `setup.py` will demand doing something else important.) This way, building is done only once locally, and not repeatedly for/by each user.